### PR TITLE
Fix stack overflow in Counter contructor.

### DIFF
--- a/src/counter.jl
+++ b/src/counter.jl
@@ -21,7 +21,7 @@ import Base: done, next, start
 type Counter
     max::Vector{Int}
 end
-Counter(sz) = Counter(Int[sz...])
+Counter(sz::Tuple) = Counter(Int[sz...])
 
 function start(c::Counter)
     N = length(c.max)


### PR DESCRIPTION
On julia master, I see that

```
InterpGrid([0.0], BCnearest, InterpNearest)
```

causes a stack overflow because of construction of a `Counter`. Must have been broken by the recent change to convert constructor inputs by default.

I wasn't quite sure what case you were trying to grab with this outer constructor, so I tried the simplest thing that worked.
