### PR TITLE
Fix #55

### DIFF
--- a/src/interp.jl
+++ b/src/interp.jl
@@ -603,18 +603,18 @@ function interp_coords_1d(coord1d::Vector{Int}, ::Type{InterpLinear})
 end
 # version for indices
 function interp_coords_1d{T,BC<:BoundaryCondition}(coord1d::Vector{Int}, ::Type{BC}, ::Type{InterpLinear}, x::T, len::Int)
-    ifx = trunc(Int, x)
+    ifx = floor(Int, x)
     dx = x-ifx
     ifx -= x < convert(T, ifx)
     ix = wrap(BC, ifx, len)
     @inbounds coord1d[1] = ix
-    iswrap = (ix == len && dx > 0)
-    @inbounds coord1d[2] = wrap(BC, ix+1, len)
+    iswrap = (ix == len && dx > 0) || (ix == 1 && ifx < 1)
+    @inbounds coord1d[2] = iswrap ? ix : wrap(BC, ix+1, len)
     return ix, dx, iswrap
 end
 function interp_coords_1d{T}(coord1d::Vector{Int}, ::Type{BCreflect}, ::Type{InterpLinear}, x::T, len::Int)
     ix = mod(floor(Int, x)-1, 2*len)
-    dx = x-trunc(x)
+    dx = x-floor(Int, x)
     if ix < len
         ix += 1
         ixp = ix+1


### PR DESCRIPTION
Thanks to @mbauman's troubleshooting it seems this was a quite easy fix; the following plots look reasonable for both linear and quadratic interpolation (only linear shown):

```julia
# using Gadfly, DataFrames
reload("Grid")

f(x) = sin(2pi * (x-1) / 10)
dfs = Array(DataFrame,0)

for (i,bc) in enumerate([
        Grid.BCnan,
        Grid.BCna,
        Grid.BCperiodic,
        Grid.BCreflect,
        Grid.BCnearest,
        Grid.BCfill])
    itp = bc != Grid.BCfill ? Grid.InterpGrid(f(1:11), bc, Grid.InterpLinear) :
        Grid.InterpGrid(f(1:11), 1, Grid.InterpLinear)
    push!(dfs, DataFrame(x=-9:.1:40,y=[itp[x]+(i-1)*3 for x in -9:.1:40],t="$bc"))
end

df = vcat(dfs)
plot(df,x=:x,y=:y,color=:t,Geom.path,Guide.colorkey("Boundary condition"))
```

![bcs](https://cloud.githubusercontent.com/assets/1550920/7050213/03911ce2-de20-11e4-8867-74a6aa3dc0e0.png)

I didn't test cubic interpolation yet simply because I know that it's not rock solid anyway, so I wanted to get this up for a Travis run first. (Did any tests break from this behavior before? If not, what's the best way to test that this actually works the way we want it?)