### PR TITLE
v0.4 tuple vararg syntax

### DIFF
--- a/src/interp.jl
+++ b/src/interp.jl
@@ -323,7 +323,7 @@ type InterpIrregular{T<:Number, S, N, BC<:BoundaryCondition, IT<:InterpType} <: 
 end
 InterpIrregular{T<:Number, BC<:BoundaryCondition, IT<:Union(InterpNearest,InterpLinear)}(grid::Vector{T}, A::AbstractArray, ::Type{BC}, ::Type{IT}) =
     InterpIrregular(Vector{T}[grid], A, BC, IT) # special 1d syntax
-InterpIrregular{T<:Number, BC<:BoundaryCondition, IT<:Union(InterpNearest,InterpLinear)}(grid::(Vector{T}...), A::AbstractArray, ::Type{BC}, ::Type{IT}) =
+InterpIrregular{T<:Number, BC<:BoundaryCondition, IT<:Union(InterpNearest,InterpLinear)}(grid::(@compat Tuple{Vararg{Vector{T}}}), A::AbstractArray, ::Type{BC}, ::Type{IT}) =
     InterpIrregular(Vector{T}[grid...], A, BC, IT)
 function InterpIrregular{T<:Number, S, N, BC<:BoundaryCondition, IT<:Union(InterpNearest,InterpLinear)}(grid::Vector{Vector{T}}, A::AbstractArray{S, N}, ::Type{BC}, ::Type{IT})
     if length(grid) != 1

--- a/test/derivative_numer.jl
+++ b/test/derivative_numer.jl
@@ -23,7 +23,7 @@ function derivative_numer{T<:Number}(func::Function, x::Array{T}, index::Int, h:
     x[index] = xsave
     return (vp-vm)/(xp-xm)
 end
-function derivative2_numer{T<:Number}(func::Function, x::Array{T}, index::(Int,Int,), h::T)
+function derivative2_numer{T<:Number}(func::Function, x::Array{T}, index::(@compat Tuple{Int,Int}), h::T)
     if index[1] == index[2] # 2nd order derivative in one direction
         v0 = func(x...)
         xsave = x[index[1]]
@@ -44,7 +44,7 @@ function derivative2_numer{T<:Number}(func::Function, x::Array{T}, index::(Int,I
     end
     return deriv
 end
-function derivative_numer{T<:Number}(func::Function, c::(T...,), index::Int, h::T)
+function derivative_numer{T<:Number}(func::Function, c::(@compat Tuple{Vararg{T}}), index::Int, h::T)
     x = [c...]
     xsave = x[index]
     xp = xsave + h
@@ -56,7 +56,7 @@ function derivative_numer{T<:Number}(func::Function, c::(T...,), index::Int, h::
     x[index] = xsave
     return (vp-vm)/(xp-xm)
 end
-function derivative2_numer{T<:Number}(func::Function, c::(T...,), index::(Int,Int,), h::T)
+function derivative2_numer{T<:Number}(func::Function, c::(@compat Tuple{Vararg{T}}), index::(@compat Tuple{Int,Int}), h::T)
     x = [c...]
     return derivative2_numer(func, x, index, h)
 end
@@ -81,7 +81,7 @@ function derivative_numer{T<:Number}(func::Function, x, index::Int, h::Vector{T}
     end
     return d
 end
-function derivative2_numer{T<:Number}(func::Function, x, index::(Int,Int,), h::Vector{T})
+function derivative2_numer{T<:Number}(func::Function, x, index::(@compat Tuple{Int,Int}), h::Vector{T})
     d = zeros(T, length(h))
     for i = 1:length(h)
         d[i] = derivative2_numer(func, x, index, h[i])
@@ -90,7 +90,7 @@ function derivative2_numer{T<:Number}(func::Function, x, index::(Int,Int,), h::V
 end
 derivative_numer{T<:Number}(func::Function, x::T) = derivative_numer(func, x, (eps(max(abs(x),one(T))))^convert(T, 1/3))
 derivative_numer{T<:Number}(func::Function, x::Array{T}, index::Int) = derivative_numer(func, x, index, (eps(max(abs(x[index]),one(T))))^convert(T, 1/3))
-derivative_numer{T<:Number}(func::Function, c::(T...,), index::Int) = derivative_numer(func, c, index, (eps(max(abs(c[index]),one(T))))^convert(T, 1/3))
+derivative_numer{T<:Number}(func::Function, c::(@compat Tuple{Vararg{T}}), index::Int) = derivative_numer(func, c, index, (eps(max(abs(c[index]),one(T))))^convert(T, 1/3))
 derivative2_numer{T<:Number}(func::Function, x::T) = derivative2_numer(func, x, (eps(max(abs(x),one(T))))^convert(T,1/3))
-derivative2_numer{T<:Number}(func::Function, x::Array{T}, index::(Int,Int,)) = derivative2_numer(func, x, index, (eps(max(abs(x[index[1]]),one(T))))^convert(T, 1/3))
-derivative2_numer{T<:Number}(func::Function, c::(T...,), index::(Int,Int,)) = derivative2_numer(func, c, index, (eps(max(abs(c[index[1]]),one(T))))^convert(T, 1/3))
+derivative2_numer{T<:Number}(func::Function, x::Array{T}, index::(@compat Tuple{Int,Int})) = derivative2_numer(func, x, index, (eps(max(abs(x[index[1]]),one(T))))^convert(T, 1/3))
+derivative2_numer{T<:Number}(func::Function, c::(@compat Tuple{Vararg{T}}), index::(@compat Tuple{Int,Int})) = derivative2_numer(func, c, index, (eps(max(abs(c[index[1]]),one(T))))^convert(T, 1/3))


### PR DESCRIPTION
I'm not clear on whether the new `Tuple{Vararg{T}}` syntax is locked down, but this change at least gets `Grid` to compile and pass tests. I have to admit I'm not a fan of the `Vararg`, preferring ellipses, but I know that's been bike-shedded around extensively elsewhere.